### PR TITLE
Fix StringIndexOutOfBounds exception

### DIFF
--- a/src/main/java/edu/usf/cutr/gtfs_realtime/bullrunner/GtfsRealtimeProviderImpl.java
+++ b/src/main/java/edu/usf/cutr/gtfs_realtime/bullrunner/GtfsRealtimeProviderImpl.java
@@ -452,6 +452,10 @@ tripUpdateMap (route, vehicle, tripupdate.builder)
 			 float bearing;
 			 for (int k = 0; k < vehicleArray.length(); k++) {
 					JSONObject vehicleObj = vehicleArray.getJSONObject(k);
+
+					// We only operate on "Route A" routes and ignore everything else
+					if (vehicleObj.getString("route").length() != 7) continue; 
+
 					route = vehicleObj.getString("route").substring(6);		 			
 					JSONArray vehicleLocsArray = vehicleObj .getJSONArray("VehicleLocation");
 					

--- a/src/main/java/edu/usf/cutr/gtfs_realtime/bullrunner/GtfsRealtimeProviderImpl.java
+++ b/src/main/java/edu/usf/cutr/gtfs_realtime/bullrunner/GtfsRealtimeProviderImpl.java
@@ -453,7 +453,7 @@ tripUpdateMap (route, vehicle, tripupdate.builder)
 			 for (int k = 0; k < vehicleArray.length(); k++) {
 					JSONObject vehicleObj = vehicleArray.getJSONObject(k);
 
-					// We only operate on "Route A" routes and ignore everything else
+					// We only operate on "Route X" routes and ignore other strings
 					if (vehicleObj.getString("route").length() != 7) continue; 
 
 					route = vehicleObj.getString("route").substring(6);		 			


### PR DESCRIPTION
Fix StringIndexOutOfBounds exception when a Syncromatics route doesn't match expected "Route A" format, e.g: when a special route is running.

Fix issue #9 
